### PR TITLE
Stop disabling cache, use "shortcode->addAssets()"

### DIFF
--- a/shortcodes/GalleryPlusPlusShortcode.php
+++ b/shortcodes/GalleryPlusPlusShortcode.php
@@ -12,9 +12,6 @@ class GalleryPlusPlusShortcode extends Shortcode
      */
     public function init()
     {
-        // disable caching. see https://discourse.getgrav.org/t/plugins-and-caching/6795/8
-        $this->grav['config']->set('system.cache.enabled', false);
-
         // gallery
         $this->shortcode->getHandlers()->add('gallery', function (ShortcodeInterface $shortcode) {
             // get default settings
@@ -87,6 +84,13 @@ class GalleryPlusPlusShortcode extends Shortcode
                     "title" => $titles[1],
                     ]);
             }
+
+            // give JS and CSS so that they can be cached
+            $this->shortcode->addAssets('css', 'plugin://shortcode-gallery-plusplus/vendor/glightbox/glightbox.min.css');
+            $this->shortcode->addAssets('css', 'plugin://shortcode-gallery-plusplus/vendor/justified-gallery/justifiedGallery.min.css');
+            $this->shortcode->addAssets('js', ['jquery', 101]);
+            $this->shortcode->addAssets('js', 'plugin://shortcode-gallery-plusplus/vendor/glightbox/glightbox.min.js');
+            $this->shortcode->addAssets('js', 'plugin://shortcode-gallery-plusplus/vendor/justified-gallery/jquery.justifiedGallery.min.js');
 
             return $this->twig->processTemplate('partials/gallery-plusplus.html.twig', [
                 // gallery settings

--- a/templates/partials/gallery-plusplus.html.twig
+++ b/templates/partials/gallery-plusplus.html.twig
@@ -1,45 +1,6 @@
 {# a random id for each gallery #}
 {% set id = random() %}
 
-{# add css libraries #}
-{% block stylesheets %}
-    {% do assets.addCss('plugin://shortcode-gallery-plusplus/vendor/glightbox/glightbox.min.css') %}
-    {% do assets.addCss('plugin://shortcode-gallery-plusplus/vendor/justified-gallery/justifiedGallery.min.css') %}
-{% endblock %}
-
-{# add js libraries #}
-{% block javascripts %}
-    {% do assets.addJs('jquery', 101) %}
-    {% do assets.addJs('plugin://shortcode-gallery-plusplus/vendor/glightbox/glightbox.min.js') %}
-    {% do assets.addJs('plugin://shortcode-gallery-plusplus/vendor/justified-gallery/jquery.justifiedGallery.min.js') %}
-{% endblock %}
-
-{# add javascript for gallery and lightbox configuration #}
-{% do assets.addInlineJs(
-'$("#' ~ id ~ '").justifiedGallery({
-    rowHeight: ' ~  rowHeight  ~ ',
-    margins: ' ~  margins  ~ ',
-    lastRow: "' ~  lastRow  ~ '",
-    captions: ' ~  captions  ~ ',
-    border: ' ~  border  ~ ',
-});
-
-GLightbox({
-    selector: ".glightbox-' ~ id ~ '",
-    openEffect: "' ~ openEffect ~ '",
-    closeEffect: "' ~ closeEffect ~ '",
-    slideEffect: "' ~ slideEffect ~ '",
-    closeButton: ' ~ closeButton ~ ',
-    touchNavigation: ' ~ touchNavigation ~ ',
-    touchFollowAxis: ' ~ touchFollowAxis ~ ',
-    keyboardNavigation: ' ~ keyboardNavigation ~ ',
-    closeOnOutsideClick: ' ~ closeOnOutsideClick ~ ',
-    loop: ' ~ loop ~ ',
-    draggable: ' ~ draggable ~ ',
-    descPosition: "' ~ descPosition ~ '",
-});', { 'group': 'bottom' })
-%}
-
 {# html #}
 <p id="{{ id }}">
     {% for image in images %}
@@ -54,3 +15,27 @@ GLightbox({
     {% endfor %}
 </p>
 
+{# add javascript for gallery and lightbox configuration #}
+<script>
+$("#{{ id }}").justifiedGallery({
+    rowHeight: {{  rowHeight  }},
+    margins: {{  margins  }},
+    lastRow: "{{  lastRow  }}",
+    captions: {{  captions  }},
+    border: {{  border  }},
+});
+
+GLightbox({
+    selector: ".glightbox-{{ id }}",
+    openEffect: "{{ openEffect }}",
+    closeEffect: "{{ closeEffect }}",
+    slideEffect: "{{ slideEffect }}",
+    closeButton: {{ closeButton }},
+    touchNavigation: {{ touchNavigation }},
+    touchFollowAxis: {{ touchFollowAxis }},
+    keyboardNavigation: {{ keyboardNavigation }},
+    closeOnOutsideClick: {{ closeOnOutsideClick }},
+    loop: {{ loop }},
+    draggable: {{ draggable }},
+    descPosition: "{{ descPosition }}",
+});</script>


### PR DESCRIPTION
Hello !
Disabling cache can lead to a lot of problems, and we can use `shortcode->addAssets()` to avoid disabling it.
Tested with Grav 1.7.20 without "AdvancedPageCache" plugin (And also tested with).
Have a nice day ! ^^