### PR TITLE
Basic solution to disable thumbnails on RSS, Atom and JSON feeds from the Feed plugin

### DIFF
--- a/blueprints/default.yaml
+++ b/blueprints/default.yaml
@@ -1,0 +1,15 @@
+'@extends':
+    type: default
+    context: blueprints://pages
+
+form:
+  fields:
+    tabs:
+      fields:
+        advanced:
+          fields:
+            overrides:
+               fields:
+                 header.cache_enable:
+                   replace-description@: true
+                   description: PLUGIN_SHORTCODE_GALLERY_PLUSPLUS.CACHE_ENABLE_DESCRIPTION

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,6 +1,8 @@
 en:
   PLUGIN_SHORTCODE_GALLERY_PLUSPLUS:
 
+    CACHE_ENABLE_DESCRIPTION: "If you are using the Feed plugin and have inserted a gallery from the Shortcode Gallery++ plugin into this page, you can disable the caching of its rendering in order to disable the gallery in your RSS, Atom and JSON feeds. This way, the images will be in your feeds in full resolution, and not as thumbnails like in your HTML page. If your page is static, you can also use the AdvancedPageCache plugin (which caches the entire HTML)."
+
     # Justified Gallery
     GALLERY_SETTINGS: "Gallery Settings"
 

--- a/shortcode-gallery-plusplus.php
+++ b/shortcode-gallery-plusplus.php
@@ -3,6 +3,8 @@
 namespace Grav\Plugin;
 
 use Grav\Common\Plugin;
+use RocketTheme\Toolbox\Event\Event;
+use Grav\Common\Page\Page;
 
 /**
  * Class ShortcodeGalleryPlusPlus
@@ -10,6 +12,8 @@ use Grav\Common\Plugin;
  */
 class ShortcodeGalleryPlusPlusPlugin extends Plugin
 {
+    private ?Page $currentPage = null;
+
     /**
      * @return array
      *
@@ -24,7 +28,9 @@ class ShortcodeGalleryPlusPlusPlugin extends Plugin
     {
         return [
             'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
-            'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0]
+            'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
+            'onPageContentRaw' => ['onPageContentRaw', 1000],             // before the Shortcode Core plugin
+            'onPageContentProcessed' => ['onPageContentProcessed', 1000], // before the Shortcode Core plugin
         ];
     }
 
@@ -34,6 +40,23 @@ class ShortcodeGalleryPlusPlusPlugin extends Plugin
     public function onTwigTemplatePaths()
     {
         $this->grav['twig']->twig_paths[] = __DIR__ . '/templates';
+    }
+
+    /**
+     * Detect which page is being processed, even if it is in a collection.
+     * We store it so that our shortcode can use it.
+     */
+    public function onPageContentRaw(Event $event)
+    {
+        $this->currentPage = $event['page'];
+    }
+    public function onPageContentProcessed(Event $event)
+    {
+        $this->currentPage = $event['page'];
+    }
+    public function getCurrentPage()
+    {
+        return $this->currentPage;
     }
 
     /**

--- a/shortcode-gallery-plusplus.php
+++ b/shortcode-gallery-plusplus.php
@@ -27,11 +27,31 @@ class ShortcodeGalleryPlusPlusPlugin extends Plugin
     public static function getSubscribedEvents(): array
     {
         return [
+            'onPluginsInitialized' => ['onPluginsInitialized', 0],
             'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
             'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
             'onPageContentRaw' => ['onPageContentRaw', 1000],             // before the Shortcode Core plugin
             'onPageContentProcessed' => ['onPageContentProcessed', 1000], // before the Shortcode Core plugin
         ];
+    }
+
+    public function onPluginsInitialized()
+    {
+        if ($this->isAdmin()) {
+            $this->active = false;
+            $this->enable([
+                'onGetPageBlueprints' => ['onGetPageBlueprints', 0]
+            ]);
+        }
+    }
+
+    /**
+     * Extend page blueprints with additional configuration options.
+     */
+    public function onGetPageBlueprints($event)
+    {
+        $types = $event->types;
+        $types->scanBlueprints('plugins://' . $this->name . '/blueprints');
     }
 
     /**


### PR DESCRIPTION
Good evening,
Well then, fasten your seatbelts, it will be complicated. In order not to do bad English, I used DeepL. I think it speaks better English than me, and anyway, it's 11pm in France, and I'm too tired.

Anyway... Generating thumbnails was a good idea. However, when you use the Feed plugin to generate RSS and Atom feeds, the images appear as thumbnails in these feeds, because RSS aggregator apps don't execute Javascripts.

So you have to generate two versions of the page: One by having generated a gallery, and another by doing nothing at all (in the Shortcode handler, you return the HTML content as you received it, without transforming it).

We can detect when we are in the case of an RSS feed:
```php
$type = $this->grav['uri']->extension();
$feed_config = $this->grav['config']->get('plugins.feed');
$feed_types = array('rss','atom');
if ($feed_config && $feed_config['enable_json_feed']) $feed_types[] = 'json';

if ( $feed_config && $feed_config['enabled'] &&       // if the Feed plugin is enabled
     isset($this->grav['page']->header()->content) && // and the current page has a collection
     $feed_types && in_array($type, $feed_types) ) {  // and the Feed plugin handles it
    // then we are sure to be in a RSS feed
}
```
In fact I was inspired by what the Feed plugin does.
https://github.com/getgrav/grav-plugin-feed/blob/develop/feed.php

However, there are two problems:
* You can't get the original page object! Because `$this->grav['page']` returns the RSS feed page (a blog page), not our original page where the gallery is. That's why my lines of code above work.
* And this original page must have its rendering caching disabled (Header `cache_enable` at `0`), otherwise the rendering is generated once, and either it's detected that we're not in an RSS feed (so the behavior is the same as it is now), or the other way around, and then it's a drama because the HTML page appears with the raw images.

That's why I listen to the same events as the Shortcode Core plugin (`onPageContentRaw()` and `onPageContentProcessed()`) in order to know which page we are processing. So I can check that the page has its `cache_enable` header set to `0`.

So if a user wants to disable thumbnails in their feeds, they only have to disable the `cache_enable` option on each page where they have a gallery. Therefore, the AdvancedPageCache plugin is recommended, otherwise the HTML of the page will be regenerated at each execution. If you accept this PR, you might want to write this paragraph somewhere in your plugin documentation.

That's it, it was very annoying because the Grav API is not very well documented.
Have a nice evening! Bisous!

___

PS: It's 1am, I solved all the problems and edited this post several times.  Writing PHP while being tired is a very bad idea.

PPS: Very important: Grav is mono-threaded. If one day they decide to multi-thread it, the method it uses to retrieve the page being processed might not work anymore!