### PR TITLE
Add `loading` attribute to thumbnail `<img>` tags

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -15,7 +15,7 @@ docs: https://github.com/sal0max/grav-plugin-shortcode-gallery-plusplus/blob/mas
 license: MIT
 
 dependencies:
-  - { name: grav, version: '>=1.6.0' }
+  - { name: grav, version: '>=1.7.4' }
   - shortcode-core
 
 form:

--- a/templates/partials/gallery-plusplus.html.twig
+++ b/templates/partials/gallery-plusplus.html.twig
@@ -29,7 +29,7 @@
         {%- set resize_factor = (rowHeight * resizeFactor) / original_image.height %}
         {{ original_image
             .cropResize(original_image.width * resize_factor, original_image.height * resize_factor)
-            .html(image.title, image.alt)|raw }}
+            .loading.html(image.title, image.alt)|raw }}
         {#~ couldn't find the image inside grav, so just use the original url #}
         {%- else %}
         {{ image["image"]|raw }}


### PR DESCRIPTION
The [`<img>` tag's `loading` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) specifies when the client's browser should start load the images.

Grav has a global site setting (as of yet undocumented, but [noted in the changelog](https://learn.getgrav.org/17/advanced/grav-development/grav-17-upgrade-guide#media)) that allows site admins to specify what the value of this attribute should be. [Twig's `.loading` action](https://learn.getgrav.org/17/content/media#loading) reads this setting and adds the appropraite attribute to the `<img>` tag. This commit just adds this `.loading` twig action when the thumbnails are generated.

I don't know much about how browsers interpret the `loading` attribute, but I assume that for very large galleries that extend significantly past the viewport this might improve performance.

Thanks for the excellent plugin 👍 