### PR TITLE
Option to disable the `title` attribute on images

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Just have a look for yourself:
 | `lastRow`   | `justify`, `hide`, `nojustify`, `center`, `right` | `justify`: justifies the last row; `hide`: hides the row if it can't be justified; `nojustify`: align the last row to the left; `center`: align the last row to the center; `right`: align the last row to the right 
 | `captions`  | `true`, `false` | Enable captions that appear when the mouse hovers an image. **For caption, the alt-text of an image is used: `![caption](image.jpg)`** 
 | `border`    | dimension in pixel | The border size of the gallery. With a negative value the border will be the same as `margins`.
+| `removeTitle` | `true`, `false` | Remove the `title` attribute from `<img>` elements in the gallery. Is interesting when you have long descriptions.
 
 ## Lightbox settings
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -77,6 +77,14 @@ form:
           validate:
             min: -1
           size: small
+        gallery.removeTitle:
+          label: PLUGIN_SHORTCODE_GALLERY_PLUSPLUS.DEFAULT_REMOVE_TITLE
+          help: PLUGIN_SHORTCODE_GALLERY_PLUSPLUS.DEFAULT_REMOVE_TITLE_HELP
+          type: toggle
+          highlight: "false"
+          options:
+            "true": PLUGIN_ADMIN.ENABLED
+            "false": PLUGIN_ADMIN.DISABLED
     lightbox:
       type: section
       title: PLUGIN_SHORTCODE_GALLERY_PLUSPLUS.LIGHTBOX_SETTINGS

--- a/languages.yaml
+++ b/languages.yaml
@@ -19,6 +19,9 @@ en:
     DEFAULT_BORDER: "Border size"
     DEFAULT_BORDER_HELP: "Decide the border size of the gallery. Use '-1' to set the border the same size as the margins."
 
+    DEFAULT_REMOVE_TITLE: "Remove title attribute"
+    DEFAULT_REMOVE_TITLE_HELP: "Remove the title attribute from images elements."
+
     # GLightbox
     LIGHTBOX_SETTINGS: "Lightbox Settings"
 

--- a/shortcode-gallery-plusplus.yaml
+++ b/shortcode-gallery-plusplus.yaml
@@ -5,6 +5,7 @@ gallery:
   lastRow: nojustify
   captions: "false"
   border: 0
+  removeTitle: "false"
 lightbox:
   openEffect: zoom
   closeEffect: zoom

--- a/shortcodes/GalleryPlusPlusShortcode.php
+++ b/shortcodes/GalleryPlusPlusShortcode.php
@@ -51,6 +51,7 @@ class GalleryPlusPlusShortcode extends Shortcode
             $lastRow = $shortcode->getParameter('lastRow', $pluginConfig['gallery']['lastRow']);
             $captions = $shortcode->getParameter('captions', $pluginConfig['gallery']['captions']);
             $border = $shortcode->getParameter('border', $pluginConfig['gallery']['border']);
+            $removeTitle = $shortcode->getParameter('removeTitle', $pluginConfig['gallery']['removeTitle']);
 
             // overwrite default lightbox settings, if set by user
             $openEffect = $shortcode->getParameter('openEffect', $pluginConfig['lightbox']['openEffect']);
@@ -93,16 +94,21 @@ class GalleryPlusPlusShortcode extends Shortcode
                 // get title attribute - and strip html from it
                 // e.g.:    "<strong>Title 1</strong><br />Example 1<br/>More description<br>Bla bla"
                 // becomes: "Title 1 | Example 1 | More description | Bla bla"
-                preg_match('/title="(.*?)"/', $image, $titles);
-                if (!empty($titles)) {
-                    // replace br tags with " | "
-                    $title_clean = preg_replace('/<br *\/*>/', ' | ', html_entity_decode($titles[1]));
-                    // strip html
-                    $title_clean = strip_tags(html_entity_decode($title_clean));
-                    // set as new title
-                    $image = preg_replace('/title=".*?"/', "title=\"$title_clean\"", $image);
+                preg_match('/title="(.*?)"/', $image, $desc);
+                $title_clean = null;
+                if (!empty($desc)) {
+                    if (!filter_var($removeTitle, FILTER_VALIDATE_BOOLEAN)) {
+                        // replace br tags with " | "
+                        $title_clean = preg_replace('/<br *\/*>/', ' | ', html_entity_decode($desc[1]));
+                        // strip html
+                        $title_clean = strip_tags(html_entity_decode($title_clean));
+                        // set as new title
+                        $image = preg_replace('/title=".*?"/', "title=\"$title_clean\"", $image);
+                    } else {
+                        $image = preg_replace('/title=".*?" /', "", $image);
+                    }
                 } else {
-                    $titles[1] = null;
+                    $desc[1] = null;
                 }
 
                 // combine
@@ -111,7 +117,8 @@ class GalleryPlusPlusShortcode extends Shortcode
                     "image" => $image,
                     "src" => $links[1],
                     "alt" => $alts[1],
-                    "title" => $titles[1],
+                    "title" => $title_clean,
+                    "desc" => $desc[1],
                     ]);
             }
 

--- a/templates/partials/gallery-plusplus.html.twig
+++ b/templates/partials/gallery-plusplus.html.twig
@@ -7,7 +7,7 @@
     <a href="{{ image["src"] }}" class="glightbox-{{ id }}"
         {#- add description, if enabled #}
         {%- if descEnabled == "true" %}
-            {{- "" }} data-description="{{ image["title"]|raw }}"
+            {{- "" }} data-description="{{ image["desc"]|raw }}"
         {%- endif %}
 >
         {#~ try to generate a thumbnail image #}


### PR DESCRIPTION
Hello !
Removing the `title` attribute on images elements can be useful when the title is really long. This fixes #33.
By the way, this PR also fixes an issue where the HTML formatted description was used as title attribute on thumbnails (Instead onf the cleaned-up one). Because we are using `image.title` in the Twig template. This bug were introduced in commit 99f7839273a8de82b713d0304327aeb9d579a24a.
Have a nice day ! ^^
